### PR TITLE
Dependency bump for CVE-2020-8244

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "chownr": "^1.1.1",
     "mkdirp-classic": "^0.5.2",
     "pump": "^3.0.0",
-    "tar-stream": "^2.0.0"
+    "tar-stream": "^2.1.4"
   },
   "keywords": [
     "tar",


### PR DESCRIPTION
Upgrade to `tar-stream` version `2.1.4` so we can get `bl` version `4.0.3`.

![image](https://user-images.githubusercontent.com/283294/98398879-8de97e80-2059-11eb-9825-3fe80b9c003f.png)
